### PR TITLE
use mkdirp instead of fs.mkdir to allow for scoped packages

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -57,7 +57,7 @@ exports.execute = function (config) {
           rimraf(linkDest, function (err) {
             if (err) return done(err);
 
-            fs.mkdir(linkDest, function (err) {
+            mkdirp(linkDest, function (err) {
               if (err) return done(err);
 
               fs.writeFile(path.join(linkDest, "package.json"), JSON.stringify({


### PR DESCRIPTION
https://docs.npmjs.com/getting-started/scoped-packages

Scoped packages exist in `node_modules/@package-scope/package-name`, so using `mkdirp` will create the top level directory.