### PR TITLE
Escape backslashes in paths when generating index.js

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -65,8 +65,8 @@ exports.execute = function (config) {
                 version: require(path.join(linkSrc, "package.json")).version
               }, null, "  "), function (err) {
                 if (err) return done(err);
-
-                fs.writeFile(path.join(linkDest, "index.js"), 'module.exports = require("' + linkSrc + '");', done);
+                var linkStr = linkSrc.replace(/\\/g, "\\\\");
+                fs.writeFile(path.join(linkDest, "index.js"), 'module.exports = require("' + linkStr + '");', done);
               });
             });
           });


### PR DESCRIPTION
The solution is primitive, just a regex replace. It doesn't do full ES6
string escaping (is there even a standard way to do this?)

Closes: #6